### PR TITLE
Add higher-level color sorting, show owls last

### DIFF
--- a/src/js/dataLayer.ts
+++ b/src/js/dataLayer.ts
@@ -151,12 +151,18 @@ const STOP_TIMES = (async () => {
     }
 
     // Sort each stop's list of lines.
+    // TODO(mingwei): Do more of `getStopTimes`'s processing here, not just sorting.
     for (const list of Object.values(data)) {
-        list.sort((a, b) => {
-            return ((COLOR_GROUP_ORDER['#' + a.route_color] || 0) - (COLOR_GROUP_ORDER['#' + b.route_color] || 0))
-                || (parseInt(a.route_short_name) - parseInt(b.route_short_name))
-                || (-a.route_short_name.localeCompare(b.route_short_name));
-        });
+        list.sort((a, b) =>
+            // Sort Historic -> Metro -> Rapid+Regular -> Owl.
+            ((COLOR_GROUP_ORDER[`#${a.route_color.toUpperCase()}`] || 0) - (COLOR_GROUP_ORDER[`#${b.route_color.toUpperCase()}`] || 0)) ||
+            // Sort lines numerically: 1 -> 5 -> 38.
+            (parseInt(a.route_short_name) - parseInt(b.route_short_name)) ||
+            // Sort rapid before anything else: 9R -> 9AX or 9BX or 9.
+            (+(COLOR_RAPID != `#${a.route_color.toUpperCase()}`) - +(COLOR_RAPID != `#${b.route_color.toUpperCase()}`)) ||
+            // Sort alphabetically: 8AX -> 8BX -> 8.
+            (-a.route_short_name.localeCompare(b.route_short_name))
+        );
     }
 
     return data;

--- a/src/js/dataLayer.ts
+++ b/src/js/dataLayer.ts
@@ -153,9 +153,9 @@ const STOP_TIMES = (async () => {
     // Sort each stop's list of lines.
     for (const list of Object.values(data)) {
         list.sort((a, b) => {
-            return (parseInt(a.route_short_name) - parseInt(b.route_short_name))
-                || (-a.route_short_name.localeCompare(b.route_short_name))
-                || ((COLOR_ORDER['#' + a.route_color] || 0) - (COLOR_ORDER['#' + b.route_color] || 0));
+            return ((COLOR_GROUP_ORDER['#' + a.route_color] || 0) - (COLOR_GROUP_ORDER['#' + b.route_color] || 0))
+                || (parseInt(a.route_short_name) - parseInt(b.route_short_name))
+                || (-a.route_short_name.localeCompare(b.route_short_name));
         });
     }
 
@@ -324,10 +324,11 @@ export const COLOR_OWL = '#666666';
 export const COLOR_HISTORIC = '#B49A36';
 export const COLOR_HISTORIC_REPLACEMENT = '#CF8B29';
 
-const COLOR_ORDER = {
-    [COLOR_RAPID]: -100,
+const COLOR_GROUP_ORDER = {
+    [COLOR_HISTORIC]: -100,
+    [COLOR_RAPID]: 100,
     [COLOR_STD]: 100,
-    [COLOR_OWL]: 200,
-};
+    [COLOR_OWL]: 200
+}
 
 export const COMMIT_HASH = __defines__.COMMIT_HASH as string;


### PR DESCRIPTION
This PR adds an additional factor into the line sorting which allows certain kinds of routes to be ordered before or after others. With this change I have made owl routes show last, and historic routes show first (which I believe is the IRL Muni sign ordering), and other route types have the same sort order and thus fall back to the rest of the sorting method.

<img width="450" alt="image" src="https://user-images.githubusercontent.com/550991/187333446-85054dbf-bb77-4973-b94b-9c6a2c3d0b9d.png">
